### PR TITLE
Updated gradle properties and added bounds check

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.jvmargs=-Xmx2G
 
 # BTA
-bta_version=7.3_01
+bta_version=7.3_04
 bta_channel=release
 
 # Loader
@@ -9,7 +9,7 @@ loader_version=0.15.6-bta.7
 
 # HalpLibe
 mod_menu_version=3.0.0
-halplibe_version=5.2.1
+halplibe_version=5.3.0
 #terrain_api_version=1.4.4-7.2-pre1
 
 # Mod

--- a/src/main/java/mizurin/shieldmod/mixins/client/LivingRendererMixin.java
+++ b/src/main/java/mizurin/shieldmod/mixins/client/LivingRendererMixin.java
@@ -64,7 +64,7 @@ public abstract class LivingRendererMixin<T extends Mob> {
 	@Redirect(method = "render(Lnet/minecraft/client/render/tessellator/Tessellator;Lnet/minecraft/core/entity/Mob;DDDFF)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/entity/MobRenderer;prepareArmor(Lnet/minecraft/core/entity/Mob;IF)Z"))
 	private boolean hijackRenderPass(MobRenderer instance, T entity, int renderPass, float partialTick){
 		ShieldMod.playerArmorRenderOffset = 0;
-		if (entity instanceof Player){
+		if (entity instanceof Player && renderPass <= 3){
 			ItemStack itemstack = ((Player) entity).inventory.armorItemInSlot(3 - renderPass);
 			if (itemstack != null && itemstack.getItem() instanceof IColoredArmor){
 				// do stuff

--- a/src/main/java/mizurin/shieldmod/mixins/client/PlayerRendererMixin.java
+++ b/src/main/java/mizurin/shieldmod/mixins/client/PlayerRendererMixin.java
@@ -32,6 +32,9 @@ public abstract class PlayerRendererMixin extends MobRenderer<Player> {
 
 	@Inject(method = "prepareArmor(Lnet/minecraft/core/entity/player/Player;IF)Z", at = @At("HEAD"))
 	private void colorArmor(Player entity, int renderPass, float partialTick, CallbackInfoReturnable<Boolean> cir){
+		if(renderPass > 3){
+			return;
+		}
 		float brightness = mc.fullbright ? 1f : entity.getBrightness(0);
 		GL11.glColor4f(brightness,brightness,brightness,1f);
 		ItemStack itemstack = entity.inventory.armorItemInSlot(3 - renderPass);


### PR DESCRIPTION
Because BWA expends the armor inventory, thus inventory.armorItemInSlot runs out of bounds for values greater than 3.
Added bounds check to both LivingRenderMixin and PlayerRenderMixin.
Updated gradle properties.